### PR TITLE
Added tests for session resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ build/
 venv/
 .venv/
 .fullcount/
+
+# Notes
+scratch.md

--- a/python/fullcount/cli.py
+++ b/python/fullcount/cli.py
@@ -1,6 +1,6 @@
 import argparse
 
-from . import BeerLeagueBallers, Fullcount, generation_1, randomness
+from . import BeerLeagueBallers, Fullcount, generation_1, randomness, generators
 
 
 def generate_cli() -> argparse.ArgumentParser:
@@ -24,6 +24,9 @@ def generate_cli() -> argparse.ArgumentParser:
 
     randomness_parser = randomness.generate_cli()
     subparsers.add_parser("randomness", parents=[randomness_parser], add_help=False)
+
+    codegen_parser = generators.generate_cli()
+    subparsers.add_parser("codegen", parents=[codegen_parser], add_help=False)
 
     return parser
 

--- a/python/fullcount/data.py
+++ b/python/fullcount/data.py
@@ -7,6 +7,8 @@ from enum import Enum
 import random
 from typing import Callable, Tuple
 
+MAX_UINT256 = 2**256 - 1
+
 
 class Outcome(Enum):
     """
@@ -18,8 +20,7 @@ class Outcome(Enum):
     * - Double - 3
     * - Triple - 4
     * - HomeRun - 5
-    * - GroundOut - 6
-    * - FlyOut - 7
+    * - InPlayOut - 6
     */
     """
 
@@ -29,8 +30,7 @@ class Outcome(Enum):
     Double = 3
     Triple = 4
     HomeRun = 5
-    GroundOut = 6
-    FlyOut = 7
+    InPlayOut = 6
 
 
 class PitchType(Enum):

--- a/python/fullcount/generation_1.py
+++ b/python/fullcount/generation_1.py
@@ -11,8 +11,7 @@ Distance0: data.OutcomeDistribution = (
     1408,
     126,
     1008,
-    1500,
-    1500,
+    3000,
 )
 
 Distance1: data.OutcomeDistribution = (
@@ -22,8 +21,7 @@ Distance1: data.OutcomeDistribution = (
     1005,
     90,
     720,
-    2250,
-    2250,
+    4500,
 )
 
 Distance2: data.OutcomeDistribution = (
@@ -33,8 +31,7 @@ Distance2: data.OutcomeDistribution = (
     603,
     55,
     432,
-    2500,
-    2500,
+    5000,
 )
 
 DistanceGT2: data.OutcomeDistribution = (
@@ -44,8 +41,7 @@ DistanceGT2: data.OutcomeDistribution = (
     201,
     19,
     144,
-    1500,
-    1500,
+    3000,
 )
 
 
@@ -121,22 +117,34 @@ def rollout(
 
     for _ in range(num_samples):
         sample_pitch_type = (
-            pitch_type if pitch_type is not None else data.PitchType(random.randint(0, 1))
+            pitch_type
+            if pitch_type is not None
+            else data.PitchType(random.randint(0, 1))
         )
         sample_pitch_vertical = (
-            pitch_vertical if pitch_vertical is not None else data.VerticalLocation(random.randint(0, 4))
+            pitch_vertical
+            if pitch_vertical is not None
+            else data.VerticalLocation(random.randint(0, 4))
         )
         sample_pitch_horizontal = (
-            pitch_horizontal if pitch_horizontal is not None else data.HorizontalLocation(random.randint(0, 4))
+            pitch_horizontal
+            if pitch_horizontal is not None
+            else data.HorizontalLocation(random.randint(0, 4))
         )
         sample_swing_type = (
-            swing_type if swing_type is not None else data.SwingType(random.randint(0, 1))
+            swing_type
+            if swing_type is not None
+            else data.SwingType(random.randint(0, 1))
         )
         sample_swing_vertical = (
-            swing_vertical if swing_vertical is not None else data.VerticalLocation(random.randint(0, 4))
+            swing_vertical
+            if swing_vertical is not None
+            else data.VerticalLocation(random.randint(0, 4))
         )
         sample_swing_horizontal = (
-            swing_horizontal if swing_horizontal is not None else data.HorizontalLocation(random.randint(0, 4))
+            swing_horizontal
+            if swing_horizontal is not None
+            else data.HorizontalLocation(random.randint(0, 4))
         )
 
         results.append(
@@ -193,7 +201,9 @@ def handle_rollout(args: argparse.Namespace) -> None:
         else None,
     )
 
-    print("pitch_type,pitch_vertical,pitch_horizontal,swing_type,swing_vertical,swing_horizontal,outcome")
+    print(
+        "pitch_type,pitch_vertical,pitch_horizontal,swing_type,swing_vertical,swing_horizontal,outcome"
+    )
     for result in results:
         print(",".join([item.name for item in result]))
 

--- a/python/fullcount/generators.py
+++ b/python/fullcount/generators.py
@@ -1,0 +1,279 @@
+"""
+Code generators.
+
+Can generate:
+1. outcome_tests: Generates Forge tests to test the resolution of the outcome of a Fullcount game.
+   Each call generates up to three tests - two which test the boundary conditions for that outcome and
+   one which tests the interior. If the interior condition is equal to one of the boundary conditions,
+   two tests are generated.
+"""
+
+import argparse
+import random
+from typing import Optional
+
+from .data import (
+    l1_distance,
+    Outcome,
+    OutcomeDistribution,
+    PitchType,
+    SwingType,
+    VerticalLocation,
+    HorizontalLocation,
+    MAX_UINT256,
+)
+from .generation_1 import Distance0, Distance1, Distance2, DistanceGT2
+from .randomness import grind
+
+OUTCOME_TEST_TEMPLATE = """
+/**
+ * To generate boundary and interior condition tests for this test case:
+ * $ fullcount codegen outcome-tests --desired-outcome {outcome.value} --pitch-type {pitch_type.value} --pitch-vert {pitch_vert.value} --pitch-hor {pitch_hor.value} --swing-type {swing_type.value} --swing-vert {swing_vert.value} --swing-hor {swing_hor.value}
+ */
+function test_{pitch_nonce}_{pitch_type.name}_{pitch_vert.name}_{pitch_hor.name}_{swing_nonce}_{swing_type.name}_{swing_vert.name}_{swing_hor.name}_{outcome.name}() public {{
+    //  Nonces {pitch_nonce} and {swing_nonce} generate random number {rng} which maps to Outcome.{outcome.name}.
+
+    assertEq(game.sessionProgress(SessionID), 3);
+
+    Pitch memory pitch =
+        Pitch({pitch_nonce}, PitchSpeed.{pitch_type.name}, VerticalLocation.{pitch_vert.name}, HorizontalLocation.{pitch_hor.name});
+
+    _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+    assertEq(game.sessionProgress(SessionID), 3);
+
+    Swing memory swing = Swing(
+        {swing_nonce}, SwingType.{swing_type.name}, VerticalLocation.{swing_vert.name}, HorizontalLocation.{swing_hor.name}
+    );
+
+    _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+    assertEq(game.sessionProgress(SessionID), 4);
+
+    // Pitcher reveals first.
+    _revealPitch(SessionID, player1, pitch);
+
+    vm.startPrank(player2);
+
+    vm.expectEmit(address(game));
+    emit SessionResolved(
+        SessionID,
+        Outcome.{outcome.name},
+        PitcherNFTAddress,
+        PitcherTokenID,
+        BatterNFTAddress,
+        BatterTokenID
+    );
+
+    game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+    vm.stopPrank();
+
+    Session memory session = game.getSession(SessionID);
+    assertTrue(session.didBatterReveal);
+    assertEq(uint256(session.outcome), uint256(Outcome.{outcome.name}));
+
+    Swing memory sessionSwing = session.batterReveal;
+    assertEq(sessionSwing.nonce, swing.nonce);
+    assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+    assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+    assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+    assertEq(game.sessionProgress(SessionID), 5);
+}}
+"""
+
+
+def outcome_tests(
+    desired_outcome: Optional[Outcome],
+    pitch_type: Optional[PitchType],
+    pitch_vert: Optional[VerticalLocation],
+    pitch_hor: Optional[HorizontalLocation],
+    swing_type: Optional[SwingType],
+    swing_vert: Optional[VerticalLocation],
+    swing_hor: Optional[HorizontalLocation],
+    pitch_nonce: Optional[int],
+) -> str:
+    if swing_type == SwingType.Take:
+        raise ValueError("SwingType.Take currently not supported")
+
+    if desired_outcome is None:
+        desired_outcome = random.choice(list(Outcome))
+
+    if pitch_type is None:
+        pitch_type = random.choice(list(PitchType))
+
+    if pitch_vert is None:
+        pitch_vert = random.choice(list(VerticalLocation))
+
+    if pitch_hor is None:
+        pitch_hor = random.choice(list(HorizontalLocation))
+
+    if swing_type is None:
+        swing_type = random.choice(
+            [item for item in list(SwingType) if item != SwingType.Take]
+        )
+
+    if swing_vert is None:
+        swing_vert = random.choice(list(VerticalLocation))
+
+    if swing_hor is None:
+        swing_hor = random.choice(list(HorizontalLocation))
+
+    distance = l1_distance(
+        pitch_type, pitch_vert, pitch_hor, swing_type, swing_vert, swing_hor
+    )
+
+    outcome_distribution = DistanceGT2
+    if distance == 0:
+        outcome_distribution = Distance0
+    elif distance == 1:
+        outcome_distribution = Distance1
+    elif distance == 2:
+        outcome_distribution = Distance2
+
+    boundary_0 = sum(outcome_distribution[: desired_outcome.value])
+    boundary_1 = sum(outcome_distribution[: desired_outcome.value + 1]) - 1
+
+    rng_to_test = list(
+        set([boundary_0, boundary_1, int((boundary_0 + boundary_1) / 2)])
+    )
+
+    if pitch_nonce is None:
+        pitch_nonce = random.randint(0, MAX_UINT256)
+
+    swing_nonces = [
+        grind(pitch_nonce, None, sum(outcome_distribution), rng) for rng in rng_to_test
+    ]
+
+    tests = [
+        OUTCOME_TEST_TEMPLATE.format(
+            outcome=desired_outcome,
+            pitch_nonce=pitch_nonce,
+            pitch_type=pitch_type,
+            pitch_vert=pitch_vert,
+            pitch_hor=pitch_hor,
+            swing_nonce=swing_nonce,
+            swing_type=swing_type,
+            swing_vert=swing_vert,
+            swing_hor=swing_hor,
+            rng=rng,
+        )
+        for rng, swing_nonce in zip(rng_to_test, swing_nonces)
+    ]
+
+    return "\n\n".join(tests)
+
+
+def handle_outcome_tests(args: argparse.Namespace) -> None:
+    print(
+        outcome_tests(
+            desired_outcome=args.desired_outcome,
+            pitch_type=args.pitch_type,
+            pitch_vert=args.pitch_vert,
+            pitch_hor=args.pitch_hor,
+            swing_type=args.swing_type,
+            swing_vert=args.swing_vert,
+            swing_hor=args.swing_hor,
+            pitch_nonce=None,
+        )
+    )
+
+
+def generate_cli() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fullcount codegen")
+    parser.set_defaults(func=lambda _: parser.print_help())
+
+    subparsers = parser.add_subparsers()
+
+    outcome_help = (
+        f"Desired outcome. If not specified, generates a random desired outcome. Inputs: "
+        + ", ".join(f"{outcome.value} - {outcome.name}" for outcome in list(Outcome))
+    )
+    pitch_type_help = (
+        f"Pitch type. If not specified, generates a random pitch type. Inputs: "
+        + ", ".join(
+            f"{pitch_type.value} - {pitch_type.name}" for pitch_type in list(PitchType)
+        )
+    )
+    swing_type_help = (
+        f"Swing type. If not specified, generates a random swing type. Inputs: "
+        + ", ".join(
+            f"{swing_type.value} - {swing_type.name}" for swing_type in list(SwingType)
+        )
+    )
+    vert_help = (
+        f"Vertical location. If not specified, generates a random vertical location. Inputs: "
+        + ", ".join(f"{vert.value} - {vert.name}" for vert in list(VerticalLocation))
+    )
+    hor_help = (
+        f"Horizontal location. If not specified, generates a random horizontal location. Inputs: "
+        + ", ".join(f"{hor.value} - {hor.name}" for hor in list(HorizontalLocation))
+    )
+
+    outcome_tests_parser = subparsers.add_parser("outcome-tests")
+    outcome_tests_parser.add_argument(
+        "--desired-outcome",
+        "-o",
+        type=lambda x: Outcome(int(x)),
+        required=False,
+        default=None,
+        help=outcome_help,
+    )
+    outcome_tests_parser.add_argument(
+        "--pitch-type",
+        "-t",
+        type=lambda x: PitchType(int(x)),
+        required=False,
+        default=None,
+        help=pitch_type_help,
+    )
+    outcome_tests_parser.add_argument(
+        "--pitch-vert",
+        "-v",
+        type=lambda x: VerticalLocation(int(x)),
+        required=False,
+        default=None,
+        help=vert_help,
+    )
+    outcome_tests_parser.add_argument(
+        "--pitch-hor",
+        "-z",
+        type=lambda x: HorizontalLocation(int(x)),
+        required=False,
+        default=None,
+        help=hor_help,
+    )
+    outcome_tests_parser.add_argument(
+        "--swing-type",
+        "-s",
+        type=SwingType,
+        required=False,
+        default=None,
+        help=swing_type_help,
+    )
+    outcome_tests_parser.add_argument(
+        "--swing-vert",
+        "-V",
+        type=VerticalLocation,
+        required=False,
+        default=None,
+        help=vert_help,
+    )
+    outcome_tests_parser.add_argument(
+        "--swing-hor",
+        "-Z",
+        type=HorizontalLocation,
+        required=False,
+        default=None,
+        help=hor_help,
+    )
+    outcome_tests_parser.set_defaults(func=handle_outcome_tests)
+
+    return parser
+
+
+if __name__ == "__main__":
+    parser = generate_cli()
+    args = parser.parse_args()
+    args.func(args)

--- a/src/Fullcount.sol
+++ b/src/Fullcount.sol
@@ -571,6 +571,8 @@ contract Fullcount is StatBlockBase, EIP712 {
                 session.batterTokenID
             );
 
+            session.outcome = outcome;
+
             _unstakeNFT(session.pitcherAddress, session.pitcherTokenID);
         }
     }
@@ -620,6 +622,8 @@ contract Fullcount is StatBlockBase, EIP712 {
                 session.batterAddress,
                 session.batterTokenID
             );
+
+            session.outcome = outcome;
 
             _unstakeNFT(session.batterAddress, session.batterTokenID);
         }

--- a/src/data.sol
+++ b/src/data.sol
@@ -131,4 +131,5 @@ struct Session {
     bool didBatterReveal;
     bytes batterCommit;
     Swing batterReveal;
+    Outcome outcome;
 }

--- a/test/RandomnessConsistency.t.sol
+++ b/test/RandomnessConsistency.t.sol
@@ -60,34 +60,57 @@ contract RandomnessConsistencyTest is FullcountTestBase {
         assertEq(game.randomSample(287_349_237_429_034_239_084, 239_480_239_842_390_842_390_482_390, 10_000), 7575);
     }
 
-    // Correspsonds to distance 0 outcome tests
+    /**
+     * $ fullcount randomness inspect -n 2 -N 277 -d 10000
+     * Nonce 1: 2, Nonce 2: 2, Denominator: 10000
+     * Random sample: 4457
+     */
     function test_2_277_10000_4457() public {
-        assertEq(game.randomSample(2, 277, 10_000), 4457);  
-    }
-
-    function test_3_2245_10000_4458() public {
-        assertEq(game.randomSample(3, 2245, 10_000), 4458);  
-    }
-
-    function test_4_1260_10000_5866() public {
-        assertEq(game.randomSample(4, 1260, 10_000), 5866);  
-    }
-
-    function test_5_1904_10000_6999() public {
-        assertEq(game.randomSample(5, 1904, 10_000), 6999);  
-    }
-
-    function test_6_18702_10000_7000() public {
-        assertEq(game.randomSample(6, 18702, 10_000), 7000);  
+        assertEq(game.randomSample(2, 277, 10_000), 4457);
     }
 
     /**
-    * $ fullcount randomness inspect -n 10 -N 13750 -d 10000
-    * Nonce 1: 10, Nonce 2: 10, Denominator: 10000
-    * Random sample: 499
-    */
-    function test_10_13750_10000_499() public {
-        assertEq(game.randomSample(10, 13750, 10000), 499);
+     * $ fullcount randomness inspect -n 3 -N 2245 -d 10000
+     * Nonce 1: 3, Nonce 2: 3, Denominator: 10000
+     * Random sample: 4458
+     */
+    function test_3_2245_10000_4458() public {
+        assertEq(game.randomSample(3, 2245, 10_000), 4458);
     }
 
+    /**
+     * $ fullcount randomness inspect -n 4 -N 1260 -d 10000
+     * Nonce 1: 4, Nonce 2: 4, Denominator: 10000
+     * Random sample: 5866
+     */
+    function test_4_1260_10000_5866() public {
+        assertEq(game.randomSample(4, 1260, 10_000), 5866);
+    }
+
+    /**
+     * $ fullcount randomness inspect -n 5 -N 1904 -d 10000
+     * Nonce 1: 5, Nonce 2: 5, Denominator: 10000
+     * Random sample: 6999
+     */
+    function test_5_1904_10000_6999() public {
+        assertEq(game.randomSample(5, 1904, 10_000), 6999);
+    }
+
+    /**
+     * $ fullcount randomness inspect -n 6 -N 18702 -d 10000
+     * Nonce 1: 6, Nonce 2: 6, Denominator: 10000
+     * Random sample: 7000
+     */
+    function test_6_18702_10000_7000() public {
+        assertEq(game.randomSample(6, 18_702, 10_000), 7000);
+    }
+
+    /**
+     * $ fullcount randomness inspect -n 10 -N 13750 -d 10000
+     * Nonce 1: 10, Nonce 2: 10, Denominator: 10000
+     * Random sample: 499
+     */
+    function test_10_13750_10000_499() public {
+        assertEq(game.randomSample(10, 13_750, 10_000), 499);
+    }
 }

--- a/test/RandomnessConsistency.t.sol
+++ b/test/RandomnessConsistency.t.sol
@@ -59,4 +59,35 @@ contract RandomnessConsistencyTest is FullcountTestBase {
     function test_287349237429034239084_239480239842390842390482390_10000_7575() public {
         assertEq(game.randomSample(287_349_237_429_034_239_084, 239_480_239_842_390_842_390_482_390, 10_000), 7575);
     }
+
+    // Correspsonds to distance 0 outcome tests
+    function test_2_277_10000_4457() public {
+        assertEq(game.randomSample(2, 277, 10_000), 4457);  
+    }
+
+    function test_3_2245_10000_4458() public {
+        assertEq(game.randomSample(3, 2245, 10_000), 4458);  
+    }
+
+    function test_4_1260_10000_5866() public {
+        assertEq(game.randomSample(4, 1260, 10_000), 5866);  
+    }
+
+    function test_5_1904_10000_6999() public {
+        assertEq(game.randomSample(5, 1904, 10_000), 6999);  
+    }
+
+    function test_6_18702_10000_7000() public {
+        assertEq(game.randomSample(6, 18702, 10_000), 7000);  
+    }
+
+    /**
+    * $ fullcount randomness inspect -n 10 -N 13750 -d 10000
+    * Nonce 1: 10, Nonce 2: 10, Denominator: 10000
+    * Random sample: 499
+    */
+    function test_10_13750_10000_499() public {
+        assertEq(game.randomSample(10, 13750, 10000), 499);
+    }
+
 }

--- a/test/Resolution.t.sol
+++ b/test/Resolution.t.sol
@@ -1,0 +1,1112 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import { Test, console2 } from "../lib/forge-std/src/Test.sol";
+import { FullcountTestBase } from "./Fullcount.t.sol";
+import { Fullcount } from "../src/Fullcount.sol";
+import {
+    PlayerType,
+    Session,
+    Pitch,
+    Swing,
+    PitchSpeed,
+    SwingType,
+    VerticalLocation,
+    HorizontalLocation,
+    Outcome
+} from "../src/data.sol";
+
+/**
+ * These tests were generated using the "fullcount codegen outcome-tests" command.
+ * WARNING: Do not put manually written tests in this contract.
+ */
+contract ResolutionTest is FullcountTestBase {
+    uint256 SessionID;
+    address PitcherNFTAddress;
+    uint256 PitcherTokenID;
+    address BatterNFTAddress;
+    uint256 BatterTokenID;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        charactersMinted++;
+        uint256 tokenID = charactersMinted;
+
+        otherCharactersMinted++;
+        uint256 otherTokenID = otherCharactersMinted;
+
+        characterNFTs.mint(player1, tokenID);
+        otherCharacterNFTs.mint(player2, otherTokenID);
+
+        vm.startPrank(player1);
+
+        characterNFTs.approve(address(game), tokenID);
+
+        uint256 sessionID = game.startSession(address(characterNFTs), tokenID, PlayerType.Pitcher);
+
+        vm.stopPrank();
+
+        vm.startPrank(player2);
+
+        otherCharacterNFTs.approve(address(game), otherTokenID);
+
+        game.joinSession(sessionID, address(otherCharacterNFTs), otherTokenID);
+
+        vm.stopPrank();
+
+        SessionID = sessionID;
+        PitcherNFTAddress = address(characterNFTs);
+        PitcherTokenID = tokenID;
+        BatterNFTAddress = address(otherCharacterNFTs);
+        BatterTokenID = otherTokenID;
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 2 --pitch-type 0 --pitch-vert 0 --pitch-hor 3 --swing-type 1
+     * --swing-vert 0 --swing-hor 0
+     */
+    function test_1049021687222126610802454284509212319382457272717699306926378180865829833280_Fast_HighBall_OutsideStrike_14846_Power_HighBall_InsideBall_Single(
+    )
+        public
+    {
+        //  Nonces 1049021687222126610802454284509212319382457272717699306926378180865829833280 and 14846 generate
+        // random number 6000 which maps to Outcome.Single.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            1_049_021_687_222_126_610_802_454_284_509_212_319_382_457_272_717_699_306_926_378_180_865_829_833_280,
+            PitchSpeed.Fast,
+            VerticalLocation.HighBall,
+            HorizontalLocation.OutsideStrike
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing = Swing(14_846, SwingType.Power, VerticalLocation.HighBall, HorizontalLocation.InsideBall);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.Single, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.Single));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 2 --pitch-type 0 --pitch-vert 0 --pitch-hor 3 --swing-type 1
+     * --swing-vert 0 --swing-hor 0
+     */
+    function test_1049021687222126610802454284509212319382457272717699306926378180865829833280_Fast_HighBall_OutsideStrike_5672_Power_HighBall_InsideBall_Single(
+    )
+        public
+    {
+        //  Nonces 1049021687222126610802454284509212319382457272717699306926378180865829833280 and 5672 generate random
+        // number 6635 which maps to Outcome.Single.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            1_049_021_687_222_126_610_802_454_284_509_212_319_382_457_272_717_699_306_926_378_180_865_829_833_280,
+            PitchSpeed.Fast,
+            VerticalLocation.HighBall,
+            HorizontalLocation.OutsideStrike
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing = Swing(5672, SwingType.Power, VerticalLocation.HighBall, HorizontalLocation.InsideBall);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.Single, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.Single));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 2 --pitch-type 0 --pitch-vert 0 --pitch-hor 3 --swing-type 1
+     * --swing-vert 0 --swing-hor 0
+     */
+    function test_1049021687222126610802454284509212319382457272717699306926378180865829833280_Fast_HighBall_OutsideStrike_3623_Power_HighBall_InsideBall_Single(
+    )
+        public
+    {
+        //  Nonces 1049021687222126610802454284509212319382457272717699306926378180865829833280 and 3623 generate random
+        // number 6317 which maps to Outcome.Single.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            1_049_021_687_222_126_610_802_454_284_509_212_319_382_457_272_717_699_306_926_378_180_865_829_833_280,
+            PitchSpeed.Fast,
+            VerticalLocation.HighBall,
+            HorizontalLocation.OutsideStrike
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing = Swing(3623, SwingType.Power, VerticalLocation.HighBall, HorizontalLocation.InsideBall);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.Single, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.Single));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 5 --pitch-type 0 --pitch-vert 1 --pitch-hor 3 --swing-type 0
+     * --swing-vert 3 --swing-hor 3
+     */
+    function test_13878950540724399130699174649043457636982143338026946178985896842721427747167_Fast_HighStrike_OutsideStrike_27426_Contact_LowStrike_OutsideStrike_HomeRun(
+    )
+        public
+    {
+        //  Nonces 13878950540724399130699174649043457636982143338026946178985896842721427747167 and 27426 generate
+        // random number 4568 which maps to Outcome.HomeRun.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            13_878_950_540_724_399_130_699_174_649_043_457_636_982_143_338_026_946_178_985_896_842_721_427_747_167,
+            PitchSpeed.Fast,
+            VerticalLocation.HighStrike,
+            HorizontalLocation.OutsideStrike
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing =
+            Swing(27_426, SwingType.Contact, VerticalLocation.LowStrike, HorizontalLocation.OutsideStrike);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.HomeRun, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.HomeRun));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 5 --pitch-type 0 --pitch-vert 1 --pitch-hor 3 --swing-type 0
+     * --swing-vert 3 --swing-hor 3
+     */
+    function test_13878950540724399130699174649043457636982143338026946178985896842721427747167_Fast_HighStrike_OutsideStrike_24391_Contact_LowStrike_OutsideStrike_HomeRun(
+    )
+        public
+    {
+        //  Nonces 13878950540724399130699174649043457636982143338026946178985896842721427747167 and 24391 generate
+        // random number 4783 which maps to Outcome.HomeRun.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            13_878_950_540_724_399_130_699_174_649_043_457_636_982_143_338_026_946_178_985_896_842_721_427_747_167,
+            PitchSpeed.Fast,
+            VerticalLocation.HighStrike,
+            HorizontalLocation.OutsideStrike
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing =
+            Swing(24_391, SwingType.Contact, VerticalLocation.LowStrike, HorizontalLocation.OutsideStrike);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.HomeRun, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.HomeRun));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 5 --pitch-type 0 --pitch-vert 1 --pitch-hor 3 --swing-type 0
+     * --swing-vert 3 --swing-hor 3
+     */
+    function test_13878950540724399130699174649043457636982143338026946178985896842721427747167_Fast_HighStrike_OutsideStrike_2785_Contact_LowStrike_OutsideStrike_HomeRun(
+    )
+        public
+    {
+        //  Nonces 13878950540724399130699174649043457636982143338026946178985896842721427747167 and 2785 generate
+        // random number 4999 which maps to Outcome.HomeRun.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            13_878_950_540_724_399_130_699_174_649_043_457_636_982_143_338_026_946_178_985_896_842_721_427_747_167,
+            PitchSpeed.Fast,
+            VerticalLocation.HighStrike,
+            HorizontalLocation.OutsideStrike
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing =
+            Swing(2785, SwingType.Contact, VerticalLocation.LowStrike, HorizontalLocation.OutsideStrike);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.HomeRun, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.HomeRun));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 0 --pitch-type 0 --pitch-vert 2 --pitch-hor 0 --swing-type 1
+     * --swing-vert 1 --swing-hor 1
+     */
+    function test_89945021098686570139325674050881369998229748902165957706437741571902570180120_Fast_Middle_InsideBall_11382_Power_HighStrike_InsideStrike_Strikeout(
+    )
+        public
+    {
+        //  Nonces 89945021098686570139325674050881369998229748902165957706437741571902570180120 and 11382 generate
+        // random number 0 which maps to Outcome.Strikeout.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            89_945_021_098_686_570_139_325_674_050_881_369_998_229_748_902_165_957_706_437_741_571_902_570_180_120,
+            PitchSpeed.Fast,
+            VerticalLocation.Middle,
+            HorizontalLocation.InsideBall
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing =
+            Swing(11_382, SwingType.Power, VerticalLocation.HighStrike, HorizontalLocation.InsideStrike);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.Strikeout, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.Strikeout));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 0 --pitch-type 0 --pitch-vert 2 --pitch-hor 0 --swing-type 1
+     * --swing-vert 1 --swing-hor 1
+     */
+    function test_89945021098686570139325674050881369998229748902165957706437741571902570180120_Fast_Middle_InsideBall_8307_Power_HighStrike_InsideStrike_Strikeout(
+    )
+        public
+    {
+        //  Nonces 89945021098686570139325674050881369998229748902165957706437741571902570180120 and 8307 generate
+        // random number 2999 which maps to Outcome.Strikeout.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            89_945_021_098_686_570_139_325_674_050_881_369_998_229_748_902_165_957_706_437_741_571_902_570_180_120,
+            PitchSpeed.Fast,
+            VerticalLocation.Middle,
+            HorizontalLocation.InsideBall
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing = Swing(8307, SwingType.Power, VerticalLocation.HighStrike, HorizontalLocation.InsideStrike);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.Strikeout, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.Strikeout));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 0 --pitch-type 0 --pitch-vert 2 --pitch-hor 0 --swing-type 1
+     * --swing-vert 1 --swing-hor 1
+     */
+    function test_89945021098686570139325674050881369998229748902165957706437741571902570180120_Fast_Middle_InsideBall_5872_Power_HighStrike_InsideStrike_Strikeout(
+    )
+        public
+    {
+        //  Nonces 89945021098686570139325674050881369998229748902165957706437741571902570180120 and 5872 generate
+        // random number 5999 which maps to Outcome.Strikeout.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            89_945_021_098_686_570_139_325_674_050_881_369_998_229_748_902_165_957_706_437_741_571_902_570_180_120,
+            PitchSpeed.Fast,
+            VerticalLocation.Middle,
+            HorizontalLocation.InsideBall
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing = Swing(5872, SwingType.Power, VerticalLocation.HighStrike, HorizontalLocation.InsideStrike);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.Strikeout, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.Strikeout));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 4 --pitch-type 1 --pitch-vert 1 --pitch-hor 4 --swing-type 1
+     * --swing-vert 4 --swing-hor 4
+     */
+    function test_100481080998296392191365173002285024694107022523030749537901599408673377815667_Slow_HighStrike_OutsideBall_13874_Power_LowBall_OutsideBall_Triple(
+    )
+        public
+    {
+        //  Nonces 100481080998296392191365173002285024694107022523030749537901599408673377815667 and 13874 generate
+        // random number 6837 which maps to Outcome.Triple.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            100_481_080_998_296_392_191_365_173_002_285_024_694_107_022_523_030_749_537_901_599_408_673_377_815_667,
+            PitchSpeed.Slow,
+            VerticalLocation.HighStrike,
+            HorizontalLocation.OutsideBall
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing = Swing(13_874, SwingType.Power, VerticalLocation.LowBall, HorizontalLocation.OutsideBall);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.Triple, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.Triple));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 4 --pitch-type 1 --pitch-vert 1 --pitch-hor 4 --swing-type 1
+     * --swing-vert 4 --swing-hor 4
+     */
+    function test_100481080998296392191365173002285024694107022523030749537901599408673377815667_Slow_HighStrike_OutsideBall_1859_Power_LowBall_OutsideBall_Triple(
+    )
+        public
+    {
+        //  Nonces 100481080998296392191365173002285024694107022523030749537901599408673377815667 and 1859 generate
+        // random number 6846 which maps to Outcome.Triple.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            100_481_080_998_296_392_191_365_173_002_285_024_694_107_022_523_030_749_537_901_599_408_673_377_815_667,
+            PitchSpeed.Slow,
+            VerticalLocation.HighStrike,
+            HorizontalLocation.OutsideBall
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing = Swing(1859, SwingType.Power, VerticalLocation.LowBall, HorizontalLocation.OutsideBall);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.Triple, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.Triple));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 4 --pitch-type 1 --pitch-vert 1 --pitch-hor 4 --swing-type 1
+     * --swing-vert 4 --swing-hor 4
+     */
+    function test_100481080998296392191365173002285024694107022523030749537901599408673377815667_Slow_HighStrike_OutsideBall_14754_Power_LowBall_OutsideBall_Triple(
+    )
+        public
+    {
+        //  Nonces 100481080998296392191365173002285024694107022523030749537901599408673377815667 and 14754 generate
+        // random number 6855 which maps to Outcome.Triple.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            100_481_080_998_296_392_191_365_173_002_285_024_694_107_022_523_030_749_537_901_599_408_673_377_815_667,
+            PitchSpeed.Slow,
+            VerticalLocation.HighStrike,
+            HorizontalLocation.OutsideBall
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing = Swing(14_754, SwingType.Power, VerticalLocation.LowBall, HorizontalLocation.OutsideBall);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.Triple, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.Triple));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 3 --pitch-type 0 --pitch-vert 2 --pitch-hor 3 --swing-type 1
+     * --swing-vert 3 --swing-hor 1
+     */
+    function test_27396150803863136439008615961271347825519983904573989306967321670860879085882_Fast_Middle_OutsideStrike_5335_Power_LowStrike_InsideStrike_Double(
+    )
+        public
+    {
+        //  Nonces 27396150803863136439008615961271347825519983904573989306967321670860879085882 and 5335 generate
+        // random number 6736 which maps to Outcome.Double.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            27_396_150_803_863_136_439_008_615_961_271_347_825_519_983_904_573_989_306_967_321_670_860_879_085_882,
+            PitchSpeed.Fast,
+            VerticalLocation.Middle,
+            HorizontalLocation.OutsideStrike
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing = Swing(5335, SwingType.Power, VerticalLocation.LowStrike, HorizontalLocation.InsideStrike);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.Double, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.Double));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 3 --pitch-type 0 --pitch-vert 2 --pitch-hor 3 --swing-type 1
+     * --swing-vert 3 --swing-hor 1
+     */
+    function test_27396150803863136439008615961271347825519983904573989306967321670860879085882_Fast_Middle_OutsideStrike_4531_Power_LowStrike_InsideStrike_Double(
+    )
+        public
+    {
+        //  Nonces 27396150803863136439008615961271347825519983904573989306967321670860879085882 and 4531 generate
+        // random number 6836 which maps to Outcome.Double.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            27_396_150_803_863_136_439_008_615_961_271_347_825_519_983_904_573_989_306_967_321_670_860_879_085_882,
+            PitchSpeed.Fast,
+            VerticalLocation.Middle,
+            HorizontalLocation.OutsideStrike
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing = Swing(4531, SwingType.Power, VerticalLocation.LowStrike, HorizontalLocation.InsideStrike);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.Double, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.Double));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 3 --pitch-type 0 --pitch-vert 2 --pitch-hor 3 --swing-type 1
+     * --swing-vert 3 --swing-hor 1
+     */
+    function test_27396150803863136439008615961271347825519983904573989306967321670860879085882_Fast_Middle_OutsideStrike_9787_Power_LowStrike_InsideStrike_Double(
+    )
+        public
+    {
+        //  Nonces 27396150803863136439008615961271347825519983904573989306967321670860879085882 and 9787 generate
+        // random number 6636 which maps to Outcome.Double.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            27_396_150_803_863_136_439_008_615_961_271_347_825_519_983_904_573_989_306_967_321_670_860_879_085_882,
+            PitchSpeed.Fast,
+            VerticalLocation.Middle,
+            HorizontalLocation.OutsideStrike
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing = Swing(9787, SwingType.Power, VerticalLocation.LowStrike, HorizontalLocation.InsideStrike);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.Double, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.Double));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 6 --pitch-type 0 --pitch-vert 2 --pitch-hor 2 --swing-type 1
+     * --swing-vert 2 --swing-hor 2
+     */
+    function test_111500307696102841260223026743650025952726101597964309549886540063107304466468_Fast_Middle_Middle_2841_Power_Middle_Middle_InPlayOut(
+    )
+        public
+    {
+        //  Nonces 111500307696102841260223026743650025952726101597964309549886540063107304466468 and 2841 generate
+        // random number 5500 which maps to Outcome.InPlayOut.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            111_500_307_696_102_841_260_223_026_743_650_025_952_726_101_597_964_309_549_886_540_063_107_304_466_468,
+            PitchSpeed.Fast,
+            VerticalLocation.Middle,
+            HorizontalLocation.Middle
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing = Swing(2841, SwingType.Power, VerticalLocation.Middle, HorizontalLocation.Middle);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.InPlayOut, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.InPlayOut));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 6 --pitch-type 0 --pitch-vert 2 --pitch-hor 2 --swing-type 1
+     * --swing-vert 2 --swing-hor 2
+     */
+    function test_111500307696102841260223026743650025952726101597964309549886540063107304466468_Fast_Middle_Middle_26696_Power_Middle_Middle_InPlayOut(
+    )
+        public
+    {
+        //  Nonces 111500307696102841260223026743650025952726101597964309549886540063107304466468 and 26696 generate
+        // random number 7749 which maps to Outcome.InPlayOut.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            111_500_307_696_102_841_260_223_026_743_650_025_952_726_101_597_964_309_549_886_540_063_107_304_466_468,
+            PitchSpeed.Fast,
+            VerticalLocation.Middle,
+            HorizontalLocation.Middle
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing = Swing(26_696, SwingType.Power, VerticalLocation.Middle, HorizontalLocation.Middle);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.InPlayOut, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.InPlayOut));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+
+    /**
+     * To generate boundary and interior condition tests for this test case:
+     * $ fullcount codegen outcome-tests --desired-outcome 6 --pitch-type 0 --pitch-vert 2 --pitch-hor 2 --swing-type 1
+     * --swing-vert 2 --swing-hor 2
+     */
+    function test_111500307696102841260223026743650025952726101597964309549886540063107304466468_Fast_Middle_Middle_1966_Power_Middle_Middle_InPlayOut(
+    )
+        public
+    {
+        //  Nonces 111500307696102841260223026743650025952726101597964309549886540063107304466468 and 1966 generate
+        // random number 9999 which maps to Outcome.InPlayOut.
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Pitch memory pitch = Pitch(
+            111_500_307_696_102_841_260_223_026_743_650_025_952_726_101_597_964_309_549_886_540_063_107_304_466_468,
+            PitchSpeed.Fast,
+            VerticalLocation.Middle,
+            HorizontalLocation.Middle
+        );
+
+        _commitPitch(SessionID, player1, player1PrivateKey, pitch);
+
+        assertEq(game.sessionProgress(SessionID), 3);
+
+        Swing memory swing = Swing(1966, SwingType.Power, VerticalLocation.Middle, HorizontalLocation.Middle);
+
+        _commitSwing(SessionID, player2, player2PrivateKey, swing);
+
+        assertEq(game.sessionProgress(SessionID), 4);
+
+        // Pitcher reveals first.
+        _revealPitch(SessionID, player1, pitch);
+
+        vm.startPrank(player2);
+
+        vm.expectEmit(address(game));
+        emit SessionResolved(
+            SessionID, Outcome.InPlayOut, PitcherNFTAddress, PitcherTokenID, BatterNFTAddress, BatterTokenID
+        );
+
+        game.revealSwing(SessionID, swing.nonce, swing.kind, swing.vertical, swing.horizontal);
+
+        vm.stopPrank();
+
+        Session memory session = game.getSession(SessionID);
+        assertTrue(session.didBatterReveal);
+        assertEq(uint256(session.outcome), uint256(Outcome.InPlayOut));
+
+        Swing memory sessionSwing = session.batterReveal;
+        assertEq(sessionSwing.nonce, swing.nonce);
+        assertEq(uint256(sessionSwing.kind), uint256(swing.kind));
+        assertEq(uint256(sessionSwing.vertical), uint256(swing.vertical));
+        assertEq(uint256(sessionSwing.horizontal), uint256(swing.horizontal));
+
+        assertEq(game.sessionProgress(SessionID), 5);
+    }
+}


### PR DESCRIPTION
To generate more such tests, use the following command:

```bash
fullcount codgen outcome-tests -h
```

The generated tests have been placed manually into `test/Resolution.t.sol`.

In the process of this work, I also added a `Session.outcome` member (see `src/data.sol`).

The Python code was out of date relative to `data.sol` - it had not yet merged `GroundOut` and `FlyOut` into `InPlayOut`. We need to be really careful to make all our derived code reflect the source of truth from `data.sol` in the future.