### PR TITLE
Session history fix

### DIFF
--- a/src/Fullcount.sol
+++ b/src/Fullcount.sol
@@ -123,12 +123,12 @@ contract Fullcount is EIP712 {
         }
 
         Session storage session = SessionState[sessionID];
-        if (session.didPitcherReveal && session.didBatterReveal) {
-            return 5;
-        } else if (session.pitcherAddress == address(0) && session.batterAddress == address(0)) {
-            return 1;
-        } else if (session.pitcherAddress == address(0) || session.batterAddress == address(0)) {
-            return 2;
+        if (session.pitcherNFT.nftAddress == address(0) || session.batterNFT.nftAddress == address(0)) {
+            if(session.pitcherLeftSession || session.batterLeftSession) {
+                return 1;
+            } else {
+                return 2;
+            }
         } else if (!session.didPitcherCommit || !session.didBatterCommit) {
             if (session.phaseStartTimestamp + SecondsPerPhase < block.timestamp) {
                 return 6;
@@ -139,6 +139,8 @@ contract Fullcount is EIP712 {
                 return 6;
             }
             return 4;
+        } else if (session.didPitcherReveal && session.didBatterReveal) {
+            return 5;
         }
 
         revert("Fullcount._sessionProgress: idiot programmer");
@@ -160,11 +162,11 @@ contract Fullcount is EIP712 {
         NumSessions++;
 
         if (role == PlayerType.Pitcher) {
-            SessionState[NumSessions].pitcherAddress = nftAddress;
-            SessionState[NumSessions].pitcherTokenID = tokenID;
+            SessionState[NumSessions].pitcherNFT.nftAddress = nftAddress;
+            SessionState[NumSessions].pitcherNFT.tokenID = tokenID;
         } else {
-            SessionState[NumSessions].batterAddress = nftAddress;
-            SessionState[NumSessions].batterTokenID = tokenID;
+            SessionState[NumSessions].batterNFT.nftAddress = nftAddress;
+            SessionState[NumSessions].batterNFT.tokenID = tokenID;
         }
 
         StakedSession[nftAddress][tokenID] = NumSessions;
@@ -186,20 +188,20 @@ contract Fullcount is EIP712 {
         require(msg.sender == nftContract.ownerOf(tokenID), "Fullcount.joinSession: msg.sender is not NFT owner");
 
         Session storage session = SessionState[sessionID];
-        if (session.pitcherAddress != address(0) && session.batterAddress != address(0)) {
+        if (session.pitcherNFT.nftAddress != address(0) && session.batterNFT.nftAddress != address(0)) {
             revert("Fullcount.joinSession: session is already full");
-        } else if (session.pitcherAddress == address(0) && session.batterAddress == address(0)) {
+        } else if (session.pitcherLeftSession || session.batterLeftSession) {
             revert("Fullcount.joinSession: opponent left session");
         }
 
         PlayerType role = PlayerType.Pitcher;
-        if (session.batterAddress == address(0)) {
+        if (session.batterNFT.nftAddress == address(0)) {
             role = PlayerType.Batter;
-            session.batterAddress = nftAddress;
-            session.batterTokenID = tokenID;
+            session.batterNFT.nftAddress = nftAddress;
+            session.batterNFT.tokenID = tokenID;
         } else {
-            session.pitcherAddress = nftAddress;
-            session.pitcherTokenID = tokenID;
+            session.pitcherNFT.nftAddress = nftAddress;
+            session.pitcherNFT.tokenID = tokenID;
         }
 
         session.phaseStartTimestamp = block.timestamp;
@@ -219,17 +221,15 @@ contract Fullcount is EIP712 {
         require(msg.sender == nftContract.ownerOf(tokenID), "Fullcount._unstakeNFT: msg.sender is not NFT owner");
 
         if (
-            SessionState[stakedSessionID].pitcherAddress == nftAddress
-                && SessionState[stakedSessionID].pitcherTokenID == tokenID
+            SessionState[stakedSessionID].pitcherNFT.nftAddress == nftAddress
+                && SessionState[stakedSessionID].pitcherNFT.tokenID == tokenID
         ) {
-            SessionState[stakedSessionID].pitcherAddress = address(0);
-            SessionState[stakedSessionID].pitcherTokenID = 0;
+            SessionState[stakedSessionID].pitcherLeftSession = true;
         } else if (
-            SessionState[stakedSessionID].batterAddress == nftAddress
-                && SessionState[stakedSessionID].batterTokenID == tokenID
+            SessionState[stakedSessionID].batterNFT.nftAddress == nftAddress
+                && SessionState[stakedSessionID].batterNFT.tokenID == tokenID
         ) {
-            SessionState[stakedSessionID].batterAddress = address(0);
-            SessionState[stakedSessionID].batterTokenID = 0;
+            SessionState[stakedSessionID].batterLeftSession = true;
         } else {
             revert("Fullcount._unstakeNFT: idiot programmer");
         }
@@ -252,14 +252,14 @@ contract Fullcount is EIP712 {
         require(_sessionProgress(sessionID) == 2, "Fullcount.abortSession: cannot abort from session in this state");
 
         // In each branch, we emit SessionAborted before unstaking because unstaking changes SessionState.
-        if (SessionState[sessionID].pitcherAddress != address(0)) {
+        if (SessionState[sessionID].pitcherNFT.nftAddress != address(0)) {
             emit SessionAborted(
-                sessionID, SessionState[sessionID].pitcherAddress, SessionState[sessionID].pitcherTokenID
+                sessionID, SessionState[sessionID].pitcherNFT.nftAddress, SessionState[sessionID].pitcherNFT.tokenID
             );
-            _unstakeNFT(SessionState[sessionID].pitcherAddress, SessionState[sessionID].pitcherTokenID);
-        } else if (SessionState[sessionID].batterAddress != address(0)) {
-            emit SessionAborted(sessionID, SessionState[sessionID].batterAddress, SessionState[sessionID].batterTokenID);
-            _unstakeNFT(SessionState[sessionID].batterAddress, SessionState[sessionID].batterTokenID);
+            _unstakeNFT(SessionState[sessionID].pitcherNFT.nftAddress, SessionState[sessionID].pitcherNFT.tokenID);
+        } else if (SessionState[sessionID].batterNFT.nftAddress != address(0)) {
+            emit SessionAborted(sessionID, SessionState[sessionID].batterNFT.nftAddress, SessionState[sessionID].batterNFT.tokenID);
+            _unstakeNFT(SessionState[sessionID].batterNFT.nftAddress, SessionState[sessionID].batterNFT.tokenID);
         } else {
             revert("Fullcount.abortSession: idiot programmer");
         }
@@ -340,9 +340,7 @@ contract Fullcount is EIP712 {
 
         Session storage session = SessionState[sessionID];
 
-        IERC721 nftContract = IERC721(session.pitcherAddress);
-
-        require(msg.sender == nftContract.ownerOf(session.pitcherTokenID), "Fullcount.commitPitch: msg.sender is not pitcher NFT owner");
+        require(msg.sender == IERC721(session.pitcherNFT.nftAddress).ownerOf(session.pitcherNFT.tokenID), "Fullcount.commitPitch: msg.sender is not pitcher NFT owner");
 
         require(!session.didPitcherCommit, "Fullcount.commitPitch: pitcher already committed");
 
@@ -365,9 +363,7 @@ contract Fullcount is EIP712 {
 
         Session storage session = SessionState[sessionID];
 
-        IERC721 nftContract = IERC721(session.batterAddress);
-
-        require(msg.sender == nftContract.ownerOf(session.batterTokenID), "Fullcount.commitSwing: msg.sender is not batter NFT owner");
+        require(msg.sender == IERC721(session.batterNFT.nftAddress).ownerOf(session.batterNFT.tokenID), "Fullcount.commitSwing: msg.sender is not batter NFT owner");
 
         require(!session.didBatterCommit, "Fullcount.commitSwing: batter already committed");
 
@@ -514,9 +510,7 @@ contract Fullcount is EIP712 {
 
         Session storage session = SessionState[sessionID];
 
-        IERC721 nftContract = IERC721(session.pitcherAddress);
-
-        require(msg.sender == nftContract.ownerOf(session.pitcherTokenID), "Fullcount.revealPitch: msg.sender is not pitcher NFT owner");
+        require(msg.sender == IERC721(session.pitcherNFT.nftAddress).ownerOf(session.pitcherNFT.tokenID), "Fullcount.revealPitch: msg.sender is not pitcher NFT owner");
 
         require(!session.didPitcherReveal, "Fullcount.revealPitch: pitcher already revealed");
 
@@ -536,15 +530,15 @@ contract Fullcount is EIP712 {
             emit SessionResolved(
                 sessionID,
                 outcome,
-                session.pitcherAddress,
-                session.pitcherTokenID,
-                session.batterAddress,
-                session.batterTokenID
+                session.pitcherNFT.nftAddress,
+                session.pitcherNFT.tokenID,
+                session.batterNFT.nftAddress,
+                session.batterNFT.tokenID
             );
 
             session.outcome = outcome;
 
-            _unstakeNFT(session.pitcherAddress, session.pitcherTokenID);
+            _unstakeNFT(session.pitcherNFT.nftAddress, session.pitcherNFT.tokenID);
         }
     }
 
@@ -565,9 +559,7 @@ contract Fullcount is EIP712 {
 
         Session storage session = SessionState[sessionID];
 
-        IERC721 nftContract = IERC721(session.batterAddress);
-
-        require(msg.sender == nftContract.ownerOf(session.batterTokenID), "Fullcount.revealSwing: msg.sender is not batter NFT owner");
+        require(msg.sender == IERC721(session.batterNFT.nftAddress).ownerOf(session.batterNFT.tokenID), "Fullcount.revealSwing: msg.sender is not batter NFT owner");
 
         require(!session.didBatterReveal, "Fullcount.revealSwing: batter already revealed");
 
@@ -587,15 +579,15 @@ contract Fullcount is EIP712 {
             emit SessionResolved(
                 sessionID,
                 outcome,
-                session.pitcherAddress,
-                session.pitcherTokenID,
-                session.batterAddress,
-                session.batterTokenID
+                session.pitcherNFT.nftAddress,
+                session.pitcherNFT.tokenID,
+                session.batterNFT.nftAddress,
+                session.batterNFT.tokenID
             );
 
             session.outcome = outcome;
 
-            _unstakeNFT(session.batterAddress, session.batterTokenID);
+            _unstakeNFT(session.batterNFT.nftAddress, session.batterNFT.tokenID);
         }
     }
 }

--- a/src/Fullcount.sol
+++ b/src/Fullcount.sol
@@ -54,7 +54,7 @@ Functionality:
       second commit, then the session is cancelled and both players may unstake their NFTs.
  */
 contract Fullcount is EIP712 {
-    string public constant FullcountVersion = "0.0.2";
+    string public constant FullcountVersion = "0.0.3";
 
     uint256 public SecondsPerPhase;
 

--- a/src/data.sol
+++ b/src/data.sol
@@ -114,22 +114,27 @@ struct Swing {
     HorizontalLocation horizontal;
 }
 
+struct NFT {
+    address nftAddress;
+    uint256 tokenID;
+}
+
 /*
 Session represents the state of a Fullcount session.
 */
 struct Session {
     uint256 phaseStartTimestamp;
-    address pitcherAddress;
-    uint256 pitcherTokenID;
+    NFT pitcherNFT;
     bool didPitcherCommit;
     bool didPitcherReveal;
     bytes pitcherCommit;
     Pitch pitcherReveal;
-    address batterAddress;
-    uint256 batterTokenID;
+    NFT batterNFT;
     bool didBatterCommit;
     bool didBatterReveal;
     bytes batterCommit;
     Swing batterReveal;
     Outcome outcome;
+    bool pitcherLeftSession;
+    bool batterLeftSession;
 }

--- a/test/Fullcount.t.sol
+++ b/test/Fullcount.t.sol
@@ -198,9 +198,9 @@ contract FullcountTestBase is Test {
 contract FullcountTestDeployment is FullcountTestBase {
     function test_Deployment() public {
         vm.expectEmit();
-        emit FullcountDeployed("0.0.2", secondsPerPhase);
+        emit FullcountDeployed("0.0.3", secondsPerPhase);
         Fullcount newGame = new Fullcount(secondsPerPhase);
-        assertEq(newGame.FullcountVersion(), "0.0.2");
+        assertEq(newGame.FullcountVersion(), "0.0.3");
         assertEq(newGame.SecondsPerPhase(), secondsPerPhase);
         assertEq(newGame.NumSessions(), 0);
     }

--- a/test/Fullcount.t.sol
+++ b/test/Fullcount.t.sol
@@ -237,10 +237,10 @@ contract FullcountTest_startSession is FullcountTestBase {
 
         Session memory session = game.getSession(sessionID);
         assertEq(session.phaseStartTimestamp, block.timestamp);
-        assertEq(session.pitcherAddress, address(characterNFTs));
-        assertEq(session.pitcherTokenID, tokenID);
-        assertEq(session.batterAddress, address(0));
-        assertEq(session.batterTokenID, 0);
+        assertEq(session.pitcherNFT.nftAddress, address(characterNFTs));
+        assertEq(session.pitcherNFT.tokenID, tokenID);
+        assertEq(session.batterNFT.nftAddress, address(0));
+        assertEq(session.batterNFT.tokenID, 0);
 
         assertEq(game.StakedSession(address(characterNFTs), tokenID), sessionID);
     }
@@ -266,10 +266,10 @@ contract FullcountTest_startSession is FullcountTestBase {
 
         Session memory session = game.getSession(sessionID);
         assertEq(session.phaseStartTimestamp, block.timestamp);
-        assertEq(session.batterAddress, address(characterNFTs));
-        assertEq(session.batterTokenID, tokenID);
-        assertEq(session.pitcherAddress, address(0));
-        assertEq(session.pitcherTokenID, 0);
+        assertEq(session.batterNFT.nftAddress, address(characterNFTs));
+        assertEq(session.batterNFT.tokenID, tokenID);
+        assertEq(session.pitcherNFT.nftAddress, address(0));
+        assertEq(session.pitcherNFT.tokenID, 0);
 
         assertEq(game.StakedSession(address(characterNFTs), tokenID), sessionID);
     }
@@ -358,10 +358,10 @@ contract FullcountTest_joinSession is FullcountTestBase {
 
         Session memory session = game.getSession(sessionID);
         assertEq(session.phaseStartTimestamp, expectedNextPhaseTimestamp);
-        assertEq(session.pitcherAddress, address(characterNFTs));
-        assertEq(session.pitcherTokenID, tokenID);
-        assertEq(session.batterAddress, address(otherCharacterNFTs));
-        assertEq(session.batterTokenID, otherTokenID);
+        assertEq(session.pitcherNFT.nftAddress, address(characterNFTs));
+        assertEq(session.pitcherNFT.tokenID, tokenID);
+        assertEq(session.batterNFT.nftAddress, address(otherCharacterNFTs));
+        assertEq(session.batterNFT.tokenID, otherTokenID);
 
         assertEq(game.StakedSession(address(otherCharacterNFTs), otherTokenID), sessionID);
     }
@@ -401,10 +401,10 @@ contract FullcountTest_joinSession is FullcountTestBase {
 
         Session memory session = game.getSession(sessionID);
         assertEq(session.phaseStartTimestamp, expectedNextPhaseTimestamp);
-        assertEq(session.batterAddress, address(characterNFTs));
-        assertEq(session.batterTokenID, tokenID);
-        assertEq(session.pitcherAddress, address(otherCharacterNFTs));
-        assertEq(session.pitcherTokenID, otherTokenID);
+        assertEq(session.batterNFT.nftAddress, address(characterNFTs));
+        assertEq(session.batterNFT.tokenID, tokenID);
+        assertEq(session.pitcherNFT.nftAddress, address(otherCharacterNFTs));
+        assertEq(session.pitcherNFT.tokenID, otherTokenID);
 
         assertEq(game.StakedSession(address(otherCharacterNFTs), otherTokenID), sessionID);
     }
@@ -487,6 +487,9 @@ contract FullcountTest_joinSession is FullcountTestBase {
 
         assertEq(game.sessionProgress(sessionID), 1);
 
+        Session memory session = game.getSession(sessionID);
+        assertTrue(session.pitcherLeftSession);
+
         vm.startPrank(player2);
 
         vm.expectRevert("Fullcount.joinSession: opponent left session");
@@ -521,10 +524,10 @@ contract FullcountTest_abortSession is FullcountTestBase {
         assertEq(game.sessionProgress(sessionID), 2);
 
         Session memory initialSession = game.getSession(sessionID);
-        assertEq(initialSession.pitcherAddress, address(characterNFTs));
-        assertEq(initialSession.pitcherTokenID, tokenID);
-        assertEq(initialSession.batterAddress, address(0));
-        assertEq(initialSession.batterTokenID, 0);
+        assertEq(initialSession.pitcherNFT.nftAddress, address(characterNFTs));
+        assertEq(initialSession.pitcherNFT.tokenID, tokenID);
+        assertEq(initialSession.batterNFT.nftAddress, address(0));
+        assertEq(initialSession.batterNFT.tokenID, 0);
 
         vm.expectEmit();
         emit SessionAborted(sessionID, address(characterNFTs), tokenID);
@@ -533,10 +536,12 @@ contract FullcountTest_abortSession is FullcountTestBase {
         assertEq(game.sessionProgress(sessionID), 1);
 
         Session memory terminalSession = game.getSession(sessionID);
-        assertEq(terminalSession.pitcherAddress, address(0));
-        assertEq(terminalSession.pitcherTokenID, 0);
-        assertEq(terminalSession.batterAddress, address(0));
-        assertEq(terminalSession.batterTokenID, 0);
+        assertEq(terminalSession.pitcherNFT.nftAddress, address(characterNFTs));
+        assertEq(terminalSession.pitcherNFT.tokenID, tokenID);
+        assertTrue(terminalSession.pitcherLeftSession);
+        assertEq(terminalSession.batterNFT.nftAddress, address(0));
+        assertEq(terminalSession.batterNFT.tokenID, 0);
+        assertFalse(terminalSession.batterLeftSession);
 
         vm.stopPrank();
     }
@@ -553,10 +558,10 @@ contract FullcountTest_abortSession is FullcountTestBase {
         assertEq(game.sessionProgress(sessionID), 2);
 
         Session memory initialSession = game.getSession(sessionID);
-        assertEq(initialSession.batterAddress, address(characterNFTs));
-        assertEq(initialSession.batterTokenID, tokenID);
-        assertEq(initialSession.pitcherAddress, address(0));
-        assertEq(initialSession.pitcherTokenID, 0);
+        assertEq(initialSession.batterNFT.nftAddress, address(characterNFTs));
+        assertEq(initialSession.batterNFT.tokenID, tokenID);
+        assertEq(initialSession.pitcherNFT.nftAddress, address(0));
+        assertEq(initialSession.pitcherNFT.tokenID, 0);
 
         vm.expectEmit();
         emit SessionAborted(sessionID, address(characterNFTs), tokenID);
@@ -565,10 +570,12 @@ contract FullcountTest_abortSession is FullcountTestBase {
         assertEq(game.sessionProgress(sessionID), 1);
 
         Session memory terminalSession = game.getSession(sessionID);
-        assertEq(terminalSession.batterAddress, address(0));
-        assertEq(terminalSession.batterTokenID, 0);
-        assertEq(terminalSession.pitcherAddress, address(0));
-        assertEq(terminalSession.pitcherTokenID, 0);
+        assertEq(terminalSession.batterNFT.nftAddress, address(characterNFTs));
+        assertEq(terminalSession.batterNFT.tokenID, tokenID);
+        assertTrue(terminalSession.batterLeftSession);
+        assertEq(terminalSession.pitcherNFT.nftAddress, address(0));
+        assertEq(terminalSession.pitcherNFT.tokenID, 0);
+        assertFalse(terminalSession.pitcherLeftSession);
 
         vm.stopPrank();
     }
@@ -585,10 +592,10 @@ contract FullcountTest_abortSession is FullcountTestBase {
         assertEq(game.sessionProgress(sessionID), 2);
 
         Session memory initialSession = game.getSession(sessionID);
-        assertEq(initialSession.pitcherAddress, address(characterNFTs));
-        assertEq(initialSession.pitcherTokenID, tokenID);
-        assertEq(initialSession.batterAddress, address(0));
-        assertEq(initialSession.batterTokenID, 0);
+        assertEq(initialSession.pitcherNFT.nftAddress, address(characterNFTs));
+        assertEq(initialSession.pitcherNFT.tokenID, tokenID);
+        assertEq(initialSession.batterNFT.nftAddress, address(0));
+        assertEq(initialSession.batterNFT.tokenID, 0);
 
         vm.prank(player2);
 
@@ -598,10 +605,10 @@ contract FullcountTest_abortSession is FullcountTestBase {
         assertEq(game.sessionProgress(sessionID), 2);
 
         Session memory terminalSession = game.getSession(sessionID);
-        assertEq(terminalSession.pitcherAddress, address(characterNFTs));
-        assertEq(terminalSession.pitcherTokenID, tokenID);
-        assertEq(terminalSession.batterAddress, address(0));
-        assertEq(terminalSession.batterTokenID, 0);
+        assertEq(terminalSession.pitcherNFT.nftAddress, address(characterNFTs));
+        assertEq(terminalSession.pitcherNFT.tokenID, tokenID);
+        assertEq(terminalSession.batterNFT.nftAddress, address(0));
+        assertEq(terminalSession.batterNFT.tokenID, 0);
     }
 
     function testRevert_when_batter_aborted_by_nonstaker() public {
@@ -616,10 +623,10 @@ contract FullcountTest_abortSession is FullcountTestBase {
         assertEq(game.sessionProgress(sessionID), 2);
 
         Session memory initialSession = game.getSession(sessionID);
-        assertEq(initialSession.batterAddress, address(characterNFTs));
-        assertEq(initialSession.batterTokenID, tokenID);
-        assertEq(initialSession.pitcherAddress, address(0));
-        assertEq(initialSession.pitcherTokenID, 0);
+        assertEq(initialSession.batterNFT.nftAddress, address(characterNFTs));
+        assertEq(initialSession.batterNFT.tokenID, tokenID);
+        assertEq(initialSession.pitcherNFT.nftAddress, address(0));
+        assertEq(initialSession.pitcherNFT.tokenID, 0);
 
         vm.prank(player2);
 
@@ -629,10 +636,10 @@ contract FullcountTest_abortSession is FullcountTestBase {
         assertEq(game.sessionProgress(sessionID), 2);
 
         Session memory terminalSession = game.getSession(sessionID);
-        assertEq(terminalSession.batterAddress, address(characterNFTs));
-        assertEq(terminalSession.batterTokenID, tokenID);
-        assertEq(terminalSession.pitcherAddress, address(0));
-        assertEq(terminalSession.pitcherTokenID, 0);
+        assertEq(terminalSession.batterNFT.nftAddress, address(characterNFTs));
+        assertEq(terminalSession.batterNFT.tokenID, tokenID);
+        assertEq(terminalSession.pitcherNFT.nftAddress, address(0));
+        assertEq(terminalSession.pitcherNFT.tokenID, 0);
     }
 
     function testRevert_when_aborting_nonexistent_session() public {
@@ -1240,10 +1247,10 @@ contract FullcountTest_reveal is FullcountTestBase {
         BatterTokenID = otherTokenID;
 
         Session memory session = game.getSession(SessionID);
-        assertEq(session.pitcherAddress, address(characterNFTs));
-        assertEq(session.batterAddress, address(otherCharacterNFTs));
-        assertEq(session.pitcherTokenID, PitcherTokenID);
-        assertEq(session.batterTokenID, BatterTokenID);
+        assertEq(session.pitcherNFT.nftAddress, address(characterNFTs));
+        assertEq(session.batterNFT.nftAddress, address(otherCharacterNFTs));
+        assertEq(session.pitcherNFT.tokenID, PitcherTokenID);
+        assertEq(session.batterNFT.tokenID, BatterTokenID);
     }
 
     // TODO Test that only pitcher NFT owner and batter NFT owner can reveal
@@ -1275,10 +1282,12 @@ contract FullcountTest_reveal is FullcountTestBase {
         assertEq(game.sessionProgress(SessionID), 5);
 
         Session memory session = game.getSession(SessionID);
-        assertEq(session.pitcherAddress, address(characterNFTs));
-        assertEq(session.batterAddress, address(0));
-        assertEq(session.pitcherTokenID, PitcherTokenID);
-        assertEq(session.batterTokenID, 0);
+        assertEq(session.pitcherNFT.nftAddress, address(characterNFTs));
+        assertEq(session.pitcherNFT.tokenID, PitcherTokenID);
+        assertFalse(session.pitcherLeftSession);
+        assertEq(session.batterNFT.nftAddress, address(otherCharacterNFTs));
+        assertEq(session.batterNFT.tokenID, BatterTokenID);
+        assertTrue(session.batterLeftSession);
     }
 
     function test_batter_reveal_then_pitcher_reveal() public {
@@ -1307,10 +1316,12 @@ contract FullcountTest_reveal is FullcountTestBase {
         assertEq(game.sessionProgress(SessionID), 5);
 
         Session memory session = game.getSession(SessionID);
-        assertEq(session.pitcherAddress, address(0));
-        assertEq(session.batterAddress, address(otherCharacterNFTs));
-        assertEq(session.pitcherTokenID, 0);
-        assertEq(session.batterTokenID, BatterTokenID);
+        assertEq(session.pitcherNFT.nftAddress, address(characterNFTs));
+        assertEq(session.pitcherNFT.tokenID, PitcherTokenID);
+        assertTrue(session.pitcherLeftSession);
+        assertEq(session.batterNFT.nftAddress, address(otherCharacterNFTs));
+        assertEq(session.batterNFT.tokenID, BatterTokenID);
+        assertFalse(session.batterLeftSession);
     }
 }
 
@@ -1352,10 +1363,10 @@ contract FullcountTest_unstake is FullcountTestBase {
         BatterTokenID = otherTokenID;
 
         Session memory session = game.getSession(SessionID);
-        assertEq(session.pitcherAddress, address(characterNFTs));
-        assertEq(session.batterAddress, address(otherCharacterNFTs));
-        assertEq(session.pitcherTokenID, PitcherTokenID);
-        assertEq(session.batterTokenID, BatterTokenID);
+        assertEq(session.pitcherNFT.nftAddress, address(characterNFTs));
+        assertEq(session.batterNFT.nftAddress, address(otherCharacterNFTs));
+        assertEq(session.pitcherNFT.tokenID, PitcherTokenID);
+        assertEq(session.batterNFT.tokenID, BatterTokenID);
     }
 
     function _try_unstake_and_expect_invalid_state_revert(
@@ -1430,10 +1441,12 @@ contract FullcountTest_unstake is FullcountTestBase {
         assertEq(game.sessionProgress(SessionID), 5);
 
         Session memory session = game.getSession(SessionID);
-        assertEq(session.pitcherAddress, address(0));
-        assertEq(session.batterAddress, BatterNFTAddress);
-        assertEq(session.pitcherTokenID, 0);
-        assertEq(session.batterTokenID, BatterTokenID);
+        assertEq(session.pitcherNFT.nftAddress, address(characterNFTs));
+        assertEq(session.pitcherNFT.tokenID, PitcherTokenID);
+        assertTrue(session.pitcherLeftSession);
+        assertEq(session.batterNFT.nftAddress, address(otherCharacterNFTs));
+        assertEq(session.batterNFT.tokenID, BatterTokenID);
+        assertFalse(session.batterLeftSession);
 
         vm.startPrank(player2);
 
@@ -1442,10 +1455,12 @@ contract FullcountTest_unstake is FullcountTestBase {
         vm.stopPrank();
 
         session = game.getSession(SessionID);
-        assertEq(session.pitcherAddress, address(0));
-        assertEq(session.batterAddress, address(0));
-        assertEq(session.pitcherTokenID, 0);
-        assertEq(session.batterTokenID, 0);
+        assertEq(session.pitcherNFT.nftAddress, address(characterNFTs));
+        assertEq(session.pitcherNFT.tokenID, PitcherTokenID);
+        assertTrue(session.pitcherLeftSession);
+        assertEq(session.batterNFT.nftAddress, address(otherCharacterNFTs));
+        assertEq(session.batterNFT.tokenID, BatterTokenID);
+        assertTrue(session.batterLeftSession);
     }
 
     function test_pitcher_can_unstake_after_completed_session() public {
@@ -1475,10 +1490,12 @@ contract FullcountTest_unstake is FullcountTestBase {
         assertEq(game.sessionProgress(SessionID), 5);
 
         Session memory session = game.getSession(SessionID);
-        assertEq(session.pitcherAddress, PitcherNFTAddress);
-        assertEq(session.batterAddress, address(0));
-        assertEq(session.pitcherTokenID, PitcherTokenID);
-        assertEq(session.batterTokenID, 0);
+        assertEq(session.pitcherNFT.nftAddress, address(characterNFTs));
+        assertEq(session.pitcherNFT.tokenID, PitcherTokenID);
+        assertFalse(session.pitcherLeftSession);
+        assertEq(session.batterNFT.nftAddress, address(otherCharacterNFTs));
+        assertEq(session.batterNFT.tokenID, BatterTokenID);
+        assertTrue(session.batterLeftSession);
 
         vm.startPrank(player1);
 
@@ -1487,10 +1504,12 @@ contract FullcountTest_unstake is FullcountTestBase {
         vm.stopPrank();
 
         session = game.getSession(SessionID);
-        assertEq(session.pitcherAddress, address(0));
-        assertEq(session.batterAddress, address(0));
-        assertEq(session.pitcherTokenID, 0);
-        assertEq(session.batterTokenID, 0);
+        assertEq(session.pitcherNFT.nftAddress, address(characterNFTs));
+        assertEq(session.pitcherNFT.tokenID, PitcherTokenID);
+        assertTrue(session.pitcherLeftSession);
+        assertEq(session.batterNFT.nftAddress, address(otherCharacterNFTs));
+        assertEq(session.batterNFT.tokenID, BatterTokenID);
+        assertTrue(session.batterLeftSession);
     }
 
 
@@ -1545,10 +1564,12 @@ contract FullcountTest_unstake is FullcountTestBase {
         assertEq(game.sessionProgress(SessionID), 5);
 
         Session memory session = game.getSession(SessionID);
-        assertEq(session.pitcherAddress, address(0));
-        assertEq(session.batterAddress, BatterNFTAddress);
-        assertEq(session.pitcherTokenID, 0);
-        assertEq(session.batterTokenID, BatterTokenID);
+        assertEq(session.pitcherNFT.nftAddress, address(characterNFTs));
+        assertEq(session.pitcherNFT.tokenID, PitcherTokenID);
+        assertTrue(session.pitcherLeftSession);
+        assertEq(session.batterNFT.nftAddress, address(otherCharacterNFTs));
+        assertEq(session.batterNFT.tokenID, BatterTokenID);
+        assertFalse(session.batterLeftSession);
 
         vm.startPrank(randomPerson);
 


### PR DESCRIPTION
Had to start nesting some properties in session struct because of "stack too deep" check. NFT info is now stored in session.pitcherNFT.nftAddress, session.batterNFT.tokenID, etc. NFT info persists after a session is aborted, expired, or completed. You can see whether the pitcher/batter are still soft staked by checking session.pitcherLeftSession/session.batterLeftSession.