### PR TITLE
When we switched to soft staking, we allowed an NFT to start/join a s…

### DIFF
--- a/src/Fullcount.sol
+++ b/src/Fullcount.sol
@@ -152,6 +152,8 @@ contract Fullcount is EIP712 {
     function startSession(address nftAddress, uint256 tokenID, PlayerType role) external virtual returns (uint256) {
         require(_isTokenOwner(nftAddress, tokenID), "Fullcount.startSession: msg.sender is not NFT owner");
 
+        require(StakedSession[nftAddress][tokenID] == 0, "Fullcount.startSession: NFT is already staked to a session.");
+
         // Increment NumSessions. The new value is the ID of the session that was just started.
         // This is what makes sessions 1-indexed.
         NumSessions++;
@@ -179,6 +181,8 @@ contract Fullcount is EIP712 {
         require(sessionID <= NumSessions, "Fullcount.joinSession: session does not exist");
 
         require(_isTokenOwner(nftAddress, tokenID), "Fullcount.joinSession: msg.sender is not NFT owner");
+
+        require(StakedSession[nftAddress][tokenID] == 0, "Fullcount.joinSession: NFT is already staked to a session.");
 
         Session storage session = SessionState[sessionID];
         if (session.pitcherNFT.nftAddress != address(0) && session.batterNFT.nftAddress != address(0)) {


### PR DESCRIPTION
…ession while already in one. This basically corrupts the old session data. This change restricts NFTs to a single session.